### PR TITLE
Fix insecure self-validation

### DIFF
--- a/Prototype/contract_code/contracts/BenefitLockAndReleaseNoDeadline.sol
+++ b/Prototype/contract_code/contracts/BenefitLockAndReleaseNoDeadline.sol
@@ -45,13 +45,6 @@ contract BenefitLockAndReleaseNoDeadline {
 
         emit GoalStarted(msg.sender, msg.value, _stepGoal);
     }
-    function validateGoal() public {
-    Goal storage g = goals[msg.sender];
-    require(g.amount > 0, "No active goal.");
-    require(!g.validated, "Already validated.");
-    g.validated = true;
-}
-
     /// @notice Called by contract owner (oracle) to validate goal
     function validateGoal(address user) external onlyOwner {
         Goal storage goal = goals[user];


### PR DESCRIPTION
## Summary
- remove public `validateGoal()` function from `BenefitLockAndReleaseNoDeadline.sol`

## Testing
- `npm test` *(fails: no test specified)*
- `npx hardhat compile` *(fails: `hardhat: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f4c87c8832d87761d7979778fe2