### PR TITLE
Add Vercel deployment prep

### DIFF
--- a/Prototype/.env.example
+++ b/Prototype/.env.example
@@ -1,0 +1,15 @@
+# Example environment variables for BEneFIT
+# Rename this file to `.env` and fill in the values
+
+# Frontend variables (used by Create React App)
+REACT_APP_CONTRACT_ADDRESS=
+REACT_APP_GOOGLE_CLIENT_ID=
+REACT_APP_SERVER_URL=http://localhost:5050
+
+# Backend variables
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+RPC_URL=
+PRIVATE_KEY=
+SERVER_URL=http://localhost:5050
+FRONTEND_URL=http://localhost:3000

--- a/Prototype/README.md
+++ b/Prototype/README.md
@@ -57,3 +57,22 @@ That's it!
 
 ✅ Now you are ready to interact with your decentralized fitness app!
 
+---
+
+## 🚢 Deploying the React Client to Vercel
+
+1. **Build the frontend**
+   ```bash
+   cd client
+   npm install
+   npm run build
+   ```
+2. **Create a new Vercel project** and set the project root to `Prototype/client` if importing from Git.
+3. **Add environment variables** in the Vercel dashboard:
+   - `REACT_APP_CONTRACT_ADDRESS` – address of the deployed contract
+   - `REACT_APP_GOOGLE_CLIENT_ID` – OAuth client ID for Google Fit
+   - `REACT_APP_SERVER_URL` – URL of the backend (e.g. `https://your-api.vercel.app`)
+4. **Deploy**. Vercel will serve the static React build.
+
+If you also deploy the backend (e.g., as a separate service), configure `SERVER_URL` and `FRONTEND_URL` there so OAuth redirects work correctly.
+

--- a/Prototype/client/package-lock.json
+++ b/Prototype/client/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dotenv": "^16.5.0",
         "ethers": "^6.13.7",
         "framer-motion": "^12.9.4",
         "react": "^19.1.0",
@@ -6677,18 +6676,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {

--- a/Prototype/client/package.json
+++ b/Prototype/client/package.json
@@ -13,7 +13,6 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "dotenv": "^16.5.0",
     "ethers": "^6.13.7",
     "framer-motion": "^12.9.4",
     "react": "^19.1.0",

--- a/Prototype/client/src/components/BenefitStakeForm.js
+++ b/Prototype/client/src/components/BenefitStakeForm.js
@@ -6,9 +6,11 @@ import BenefitABI from "../abi/BenefitLockAndReleaseNoDeadline.json";
 import { motion } from "framer-motion";
 import toast, { Toaster } from "react-hot-toast";
 import { FaEthereum, FaBullseye, FaLock } from "react-icons/fa";
-require("dotenv").config();
 
-const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS
+// Environment variables are injected at build time in Create React App when
+// they are prefixed with REACT_APP_. This allows the Vercel deployment to
+// provide values via project settings.
+const CONTRACT_ADDRESS = process.env.REACT_APP_CONTRACT_ADDRESS;
 
 // Utility function to get the network name based on chain ID
 function getNetworkName(chainId) {

--- a/Prototype/client/src/components/ChoicePage.js
+++ b/Prototype/client/src/components/ChoicePage.js
@@ -4,7 +4,6 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import { FaWalking, FaRocket } from "react-icons/fa";
-require("dotenv").config();
 
 export default function ChoicePage() {
   return (

--- a/Prototype/client/src/components/ValidateGoalForm.js
+++ b/Prototype/client/src/components/ValidateGoalForm.js
@@ -3,10 +3,15 @@ import React, { useEffect, useState } from "react";
 import { ethers } from "ethers";
 import BenefitABI from "../abi/BenefitLockAndReleaseNoDeadline.json";
 
-const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS;
-const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
-const REDIRECT_URI = "http://localhost:5050/oauth-callback";
-require("dotenv").config();
+// Contract and OAuth credentials are supplied via environment variables with
+// the REACT_APP_ prefix to ensure they are embedded during the build step.
+const CONTRACT_ADDRESS = process.env.REACT_APP_CONTRACT_ADDRESS;
+const GOOGLE_CLIENT_ID = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+
+// The backend base URL is configurable so that the app can point to a Vercel
+// serverless function or a local server during development.
+const API_BASE_URL = process.env.REACT_APP_SERVER_URL || "http://localhost:5050";
+const REDIRECT_URI = `${API_BASE_URL}/oauth-callback`;
 
 export default function ValidateGoalForm() {
   // State variables for managing user data and UI state

--- a/Prototype/server/index.js
+++ b/Prototype/server/index.js
@@ -5,7 +5,10 @@ const { ethers } = require("ethers");
 require("dotenv").config();
 
 const app = express();
-const PORT = 5050;
+const PORT = process.env.PORT || 5050;
+// Base URLs are configurable so the backend can run locally or on Vercel.
+const SERVER_URL = process.env.SERVER_URL || `http://localhost:${PORT}`;
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
 
 // Middleware
 app.use(cors());
@@ -28,7 +31,7 @@ app.get("/", (req, res) => {
 // OAuth callback route to exchange code for tokens
 app.get("/oauth-callback", async (req, res) => {
   const { code, state } = req.query;
-  const redirect_uri = "http://localhost:5050/oauth-callback";
+  const redirect_uri = `${SERVER_URL}/oauth-callback`;
 
   try {
     const response = await axios.post("https://oauth2.googleapis.com/token", {
@@ -45,7 +48,7 @@ app.get("/oauth-callback", async (req, res) => {
     tokenStorage.set(state, { access_token: accessToken });
 
     // 🔁 Redirect back to frontend cleanly (no token in URL)
-    res.redirect(`http://localhost:3000/validate?user=${state}`);
+    res.redirect(`${FRONTEND_URL}/validate?user=${state}`);
   } catch (error) {
     console.error("OAuth callback error", error.response?.data || error.message);
     res.status(500).send("OAuth failed");
@@ -121,7 +124,7 @@ app.post("/api/validate-onchain", async (req, res) => {
 
 // Start server
 app.listen(PORT, () => {
-  console.log(`✅ Backend running at http://localhost:${PORT}`);
+  console.log(`✅ Backend running at ${SERVER_URL}`);
 });
 
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ BEneFIT/
 
 Note: This prototype is optional and may contain simplified implementations for ETH staking and goal verification logic.
 
+Environment variables for both the backend and React client can be configured
+using the example file at `Prototype/.env.example`.
+
 ---
 
 ## 📊 Evaluation Summary


### PR DESCRIPTION
## Summary
- add environment variable example file
- document Vercel deployment steps
- use `REACT_APP_` variables in React components
- parameterize server URLs
- remove unused `dotenv` from client

## Testing
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f6a5eb0832da1cdae74ec234f25