### PR TITLE
Update setup steps for Prototype

### DIFF
--- a/Prototype/README.md
+++ b/Prototype/README.md
@@ -18,6 +18,15 @@ You should also have:
 ---
 ## 📚 How to Run
 
+### 0. Install Dependencies
+Run `npm install` once in the root `Prototype/` directory:
+```bash
+npm install
+```
+This installs all packages shared by the frontend and the backend. The `server/`
+folder does not contain its own `package.json`; it relies on these root
+dependencies.
+
 ### 1. Start the Frontend
 Go to the `client/` folder and run:
 ```bash


### PR DESCRIPTION
## Summary
- clarify single `npm install` in `Prototype`
- note that the server folder has no standalone `package.json`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_683f6ab021f0832db90605233f0864d7