### PR TITLE
Add StepVerifier verifier stub

### DIFF
--- a/Prototype/contract_code/contracts/StepVerifier.sol
+++ b/Prototype/contract_code/contracts/StepVerifier.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Minimal verifier stub used for testing
+contract StepVerifier {
+    /// @notice Verify a ZK-SNARK proof.
+    /// @dev This stub always returns true. Replace with real verifier in production.
+    /// @param a First proof element
+    /// @param b Second proof element
+    /// @param c Third proof element
+    /// @param input Public inputs to the proof
+    /// @return Whether the proof is valid
+    function verifyProof(
+        uint[2] memory a,
+        uint[2][2] memory b,
+        uint[2] memory c,
+        uint[1] memory input
+    ) public pure returns (bool) {
+        a; b; c; input; // silence unused variable warnings
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal `StepVerifier` contract stub
- `BenefitRedistributionZKP.sol` imports this verifier

## Testing
- `npx hardhat compile` *(fails: Trying to use a non-local installation of Hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_683f6aadb318832da068270ddcea0b88